### PR TITLE
Added last {target} detection and bounding boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ image_processing:
   - platform: amazon_rekognition
     aws_access_key_id: AWS_ACCESS_KEY_ID
     aws_secret_access_key: AWS_SECRET_ACCESS_KEY
-    region_name: eu-west-1 # optional region, default us-east-1
+    region_name: eu-west-1 # optional region, default is us-east-1
+    save_file_folder: /config/www/amazon-rekognition/ # Optional image storage
+    confidence: 90 # Optional, default is 80. Only used for bounding boxes atm
     target: Car # Optional target object, default Person
     source:
       - entity_id: camera.local_file
 ```
+
+### Bounding box
+
+If you set a `save_file_folder` an image will be stored with bounding boxes drawn around the objects that have own (as in, AWS returned them). The `confidence` level is used to decide what boxes should be drawn (by default this is everything above 80%).
 
 <p align="center">
 <img src="https://github.com/robmarkcole/HASS-amazon-rekognition/blob/master/development/usage.png" width="800">
@@ -33,6 +39,6 @@ image_processing:
 * For tests we have the [moto library](https://github.com/spulec/moto)
 
 ### Roadmap
-* Handle bounding boxes at the platform level
+* Handle bounding boxes at the platform level, currently only possible on a component level
 * Integrate with S3 buckets - we want a web front end to show processed images and results. Perhaps checkout [s3album](https://github.com/toehio/s3album). Alternatively [T3 looks very interesting](https://github.com/quiltdata/t4).
 * Host our own [S3 with minio](https://github.com/minio/minio) -> [on a NAS](https://docs.minio.io/docs/minio-gateway-for-nas.html) -> [Synology](https://github.com/minio/minio/issues/4210)

--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -12,7 +12,6 @@ from PIL import Image, ImageDraw
 
 import voluptuous as vol
 
-from homeassistant.util.pil import draw_box
 import homeassistant.util.dt as dt_util
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv

--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -12,6 +12,7 @@ from PIL import Image, ImageDraw
 
 import voluptuous as vol
 
+from homeassistant.util.pil import draw_box
 import homeassistant.util.dt as dt_util
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
@@ -79,18 +80,14 @@ def save_image(image, response, target, confidence, directory):
         for instance in label['Instances']:
             box = instance['BoundingBox']
 
-            line_width = 3
-            font_height = 12
-
-            left = img.width * box['Left']
-            top = img.height * box['Top']
-            width = img.width * box['Width']
-            height = img.height * box['Height']
-
-            points = ((left,top), (left + width, top), (left + width, top + height), (left , top + height), (left, top))
-            draw.line(points, fill='#00d400', width=line_width)
+            x, y, w, h = box['Left'], box['Top'], box['Width'], box['Height']
+            x_max, y_max = x + w, y + h
 
             box_label = f'{label["Name"]}: {label["Confidence"]:.1f}%'
+            draw_box(draw, (y, x, y_max, x_max), img.width, img.height, color=(0, 212, 0))
+
+            # Use draw for the text so you can give it a color that is actually readable
+            left, top, line_width, font_height = img.width * box['Left'], img.height * box['Top'], 3, 12
             draw.text((left + line_width, abs(top - line_width - font_height)), box_label)
 
     latest_save_path = directory + f'amazon_rekognition_latest_{target.lower()}.jpg'

--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -90,8 +90,8 @@ def save_image(image, response, target, confidence, directory):
             points = ((left,top), (left + width, top), (left + width, top + height), (left , top + height), (left, top))
             draw.line(points, fill='#00d400', width=line_width)
 
-            box_label = f'{label["Name"]} {label["Confidence"]:.1f}%'
-            draw.text((left + line_width, abs(top - line_width - font_height)), label['Name'])
+            box_label = f'{label["Name"]}: {label["Confidence"]:.1f}%'
+            draw.text((left + line_width, abs(top - line_width - font_height)), box_label)
 
     latest_save_path = directory + f'amazon_rekognition_latest_{target.lower()}.jpg'
     img.save(latest_save_path)

--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -2,18 +2,28 @@
 Platform that will perform object detection.
 """
 import base64
+import io
 import json
 import logging
+import os
 import time
 from datetime import timedelta
+from PIL import Image, ImageDraw
 
 import voluptuous as vol
 
+from homeassistant.util.pil import draw_box
+import homeassistant.util.dt as dt_util
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA, ImageProcessingEntity, CONF_SOURCE, CONF_ENTITY_ID,
-    CONF_NAME)
+    PLATFORM_SCHEMA, 
+    ImageProcessingEntity, 
+    ATTR_CONFIDENCE, 
+    CONF_SOURCE, 
+    CONF_ENTITY_ID,
+    CONF_NAME
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,6 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_REGION = 'region_name'
 CONF_ACCESS_KEY_ID = 'aws_access_key_id'
 CONF_SECRET_ACCESS_KEY = 'aws_secret_access_key'
+CONF_SAVE_FILE_FOLDER = "save_file_folder"
 CONF_TARGET = 'target'
 DEFAULT_TARGET = 'Person'
 
@@ -41,6 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ACCESS_KEY_ID): cv.string,
     vol.Required(CONF_SECRET_ACCESS_KEY): cv.string,
     vol.Optional(CONF_TARGET, default=DEFAULT_TARGET): cv.string,
+    vol.Optional(CONF_SAVE_FILE_FOLDER): cv.isdir,
 })
 
 
@@ -55,6 +67,35 @@ def parse_labels(response):
     """Parse the API labels data, returning objects only."""
     return {label['Name']: round(label['Confidence'], 2) for label in response['Labels']}
 
+def save_image(image, response, target, confidence, directory):
+    """Draws the actual bounding box of the detected objects."""
+    img = Image.open(io.BytesIO(bytearray(image))).convert("RGB")
+    draw = ImageDraw.Draw(img)
+
+    boxes = []
+    for label in response['Labels']:
+        if label["Confidence"] < confidence:
+            continue
+
+        for instance in label['Instances']:
+            box = instance['BoundingBox']
+
+            line_width = 3
+            font_height = 12
+
+            left = img.width * box['Left']
+            top = img.height * box['Top']
+            width = img.width * box['Width']
+            height = img.height * box['Height']
+
+            points = ((left,top), (left + width, top), (left + width, top + height), (left , top + height), (left, top))
+            draw.line(points, fill='#00d400', width=line_width)
+
+            box_label = f'{label["Name"]} {label["Confidence"]:.1f}%'
+            draw.text((left + line_width, abs(top - line_width - font_height)), label['Name'])
+
+    latest_save_path = directory + f'amazon_rekognition_latest_{target}.jpg'
+    img.save(latest_save_path)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Rekognition."""
@@ -68,12 +109,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     client = boto3.client('rekognition', **aws_config) # Will not raise error.
 
+    save_file_folder = config.get(CONF_SAVE_FILE_FOLDER)
+    if save_file_folder:
+        save_file_folder = os.path.join(save_file_folder, "")  # If no trailing / add it
+
     entities = []
     for camera in config[CONF_SOURCE]:
         entities.append(Rekognition(
             client,
             config.get(CONF_REGION),
-            config.get(CONF_TARGET),
+            config.get(CONF_TARGET).lower(), # Lowercase the target
+            config.get(ATTR_CONFIDENCE),
+            save_file_folder,
             camera[CONF_ENTITY_ID],
             camera.get(CONF_NAME),
         ))
@@ -83,27 +130,39 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class Rekognition(ImageProcessingEntity):
     """Perform object and label recognition."""
 
-    def __init__(self, client, region, target, camera_entity, name=None):
+    def __init__(self, client, region, target, confidence, save_file_folder, camera_entity, name=None):
         """Init with the client."""
         self._client = client
         self._region = region
         self._target = target
+        self._confidence = confidence
+        if save_file_folder: # Since save_file_folder is optional.
+            self._save_file_folder = save_file_folder
+        self._camera_entity = camera_entity
         if name:  # Since name is optional.
             self._name = name
         else:
             entity_name = split_entity_id(camera_entity)[1]
             self._name = "{} {} {}".format('rekognition', target, entity_name)
-        self._camera_entity = camera_entity
         self._state = None  # The number of instances of interest
+        self._last_detection = None  # The last time we detected something
         self._labels = {} # The parsed label data
+
 
     def process_image(self, image):
         """Process an image."""
         self._state = None
         self._labels = {}
+        
         response = self._client.detect_labels(Image={'Bytes': image})
         self._state = get_label_instances(response, self._target)
         self._labels = parse_labels(response)
+    
+        if self._state > 0:
+            self._last_detection = dt_util.now()
+
+        if hasattr(self, "_save_file_folder"): # Only save if folder is defined
+            save_image(image, response, self._target, self._confidence, self._save_file_folder)
 
     @property
     def camera_entity(self):
@@ -120,6 +179,8 @@ class Rekognition(ImageProcessingEntity):
         """Return device specific state attributes."""
         attr = self._labels
         attr['target'] = self._target
+        if self._last_detection:
+            attr["last_{}_detection".format(self._target)] = self._last_detection.strftime("%Y-%m-%d %H:%M:%S")
         return attr
 
     @property

--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -59,7 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def get_label_instances(response, target):
     """Get the number of instances of a target label."""
     for label in response['Labels']:
-        if label['Name'] == target:
+        if label['Name'].lower() == target.lower(): # Lowercase both to prevent any comparing issues
             return len(label['Instances'])
     return 0
 
@@ -94,7 +94,7 @@ def save_image(image, response, target, confidence, directory):
             box_label = f'{label["Name"]} {label["Confidence"]:.1f}%'
             draw.text((left + line_width, abs(top - line_width - font_height)), label['Name'])
 
-    latest_save_path = directory + f'amazon_rekognition_latest_{target}.jpg'
+    latest_save_path = directory + f'amazon_rekognition_latest_{target.lower()}.jpg'
     img.save(latest_save_path)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -118,7 +118,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         entities.append(Rekognition(
             client,
             config.get(CONF_REGION),
-            config.get(CONF_TARGET).lower(), # Lowercase the target
+            config.get(CONF_TARGET),
             config.get(ATTR_CONFIDENCE),
             save_file_folder,
             camera[CONF_ENTITY_ID],


### PR DESCRIPTION
I saw that you wanted to handle bounding boxes at the platform level, but I decided to create a PR anyway, since I would like to have that feature now (instead of later). 😄 

- Added last {target} detection
- Allow an image to be saved
  - Draws bounding boxes with their label, but only if the confidence is over the confidence passed

I haven't changed any of the tests (or even ran them), since my Python knowledge is very limited, so I do expect them to break/be broken.