### PR TITLE
Fix detected target count

### DIFF
--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -76,7 +76,10 @@ def get_label_instances(response, target):
         if (
             label["Name"].lower() == target.lower()
         ):  # Lowercase both to prevent any comparing issues
-            return len(label["Instances"])
+            if len(label["Instances"]) > 0:
+                return len(label["Instances"])
+            else:
+                return 1
     return 0
 
 


### PR DESCRIPTION
According to [AWS docs](https://docs.aws.amazon.com/rekognition/latest/dg/API_Label.html#rekognition-Type-Label-Instances), "If Label represents an object, Instances contains the bounding boxes for each instance of the detected object. Bounding boxes are returned for common object labels such as people, cars, furniture, apparel or pets.". 

This means that for some (not "common", whatever that means) detected objects AWS returns an empty list of instances. This PR somewhat fixes it: for such cases a 1 will be returned. If there are more matches, the count will be obviously wrong (since we have no way to count the real number of matches). 

It's not ideal, but at least it fixes a confusing case of the component showing a match but the sensor returning 0.