### PR TITLE
Fix KeyError: 'save_file_folder'

### DIFF
--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -106,7 +106,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     client = boto3.client("rekognition", **aws_config)
 
-    save_file_folder = config[CONF_SAVE_FILE_FOLDER]
+    save_file_folder = config.get(CONF_SAVE_FILE_FOLDER)
     if save_file_folder:
         save_file_folder = Path(save_file_folder)
 


### PR DESCRIPTION
The `config` dict might not contain the key `save_file_folder` because `save_file_folder` is an optional config option.
This diff protects against the KeyError exception when the user's config lacks `save_file_folder`.

Bug reported in:
https://community.home-assistant.io/t/integrating-blue-iris-pushover-node-red-and-amazon-rekognition/120955/115

Dev tested this way:

Comment out `save_file_folder` in the config, restart HA to reproduce the bug.
Patch image_processing.py with this diff.  Add a _LOGGER line to log `save_file_folder`.
Restart HA and confirm no exception.  Confirm log reports `save_file_folder` is `None`
