### PR TITLE
Fix latest file with no detections overwriting timestamped file

### DIFF
--- a/custom_components/amazon_rekognition/image_processing.py
+++ b/custom_components/amazon_rekognition/image_processing.py
@@ -526,7 +526,7 @@ class ObjectDetection(ImageProcessingEntity):
         _LOGGER.info("Rekognition saved file %s", latest_save_path)
         saved_image_path = latest_save_path
 
-        if self._save_timestamped_file:
+        if targets and self._save_timestamped_file:
             filename = f"{self._name}_{self._last_detection}.{self._save_file_format}"
             timestamp_save_path = directory / filename
             img.save(timestamp_save_path)


### PR DESCRIPTION
Fixes #108. Only saves timestamped file when targets are detected.